### PR TITLE
Fix Playwright timeout units and clean up PDF/video processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-2.1-green.svg)](https://github.com/seu-usuario/estrategia-downloader-pro)
+[![Version](https://img.shields.io/badge/version-3.1-green.svg)](https://github.com/seu-usuario/estrategia-downloader-pro)
 
 Downloader automatizado, seguro e profissional para cursos da plataforma Estratégia Concursos com **suporte completo a materiais complementares**.
 

--- a/downloader.py
+++ b/downloader.py
@@ -300,7 +300,7 @@ class DownloadManager:
                     '--disable-blink-features=AutomationControlled',
                     '--disable-dev-shm-usage',
                 ],
-                timeout=self.BROWSER_TIMEOUT * 1000
+                timeout=self.BROWSER_TIMEOUT
             )
             
             logger.info("✓ Navegador iniciado com sucesso")

--- a/pdf_processor.py
+++ b/pdf_processor.py
@@ -45,13 +45,6 @@ class PDFProcessor(BaseCourseProcessor):
         
         logger.info(f"📄 Processador de PDF inicializado (tipos: {self.pdf_types_to_download})")
 
-    # ... (rest of the file until _process_pdf_button)
-
-    # I will rely on the tool to match context. Since I cannot skip lines easily in ReplaceFileContent without separate chunks, 
-    # I will just update __init__ with ReplaceFileContent and then use MultiReplace or another call for the callback.
-    # Actually, I can do it in two tools or one MultiReplace. MultiReplace is safer.
-    # Let's switch to MultiReplace.
-    
     async def process_course(self, page: Page, course_url: str) -> bool:
         """
         Processa curso completo para download de PDFs.

--- a/video_processor.py
+++ b/video_processor.py
@@ -96,11 +96,11 @@ class VideoProcessor(BaseCourseProcessor):
             success_count = 0
             failed_count = 0
             
-            for aula_element in aulas:
+            for index, aula_element in enumerate(aulas, 1):
                 await self.check_cancellation()
                 
                 try:
-                    await self._process_lesson(page, aula_element, course_dir, course_url)
+                    await self._process_lesson(page, aula_element, course_dir, course_url, index)
                     success_count += 1
                 except Exception as e:
                     logger.error(f"❌ Erro ao processar aula: {e}")
@@ -126,7 +126,8 @@ class VideoProcessor(BaseCourseProcessor):
         page: Page,
         aula_element: Locator,
         course_dir: Path,
-        course_url: str
+        course_url: str,
+        index: int
     ) -> None:
         """
         Processa uma aula específica para download de vídeos.
@@ -138,7 +139,7 @@ class VideoProcessor(BaseCourseProcessor):
             course_url: URL do curso (para recuperação de erros)
         """
         try:
-            aula_id, lesson_name, _ = await self.extract_lesson_info(aula_element, 0)
+            aula_id, lesson_name, _ = await self.extract_lesson_info(aula_element, index)
             
             lesson_dir = course_dir / lesson_name
             
@@ -204,9 +205,7 @@ class VideoProcessor(BaseCourseProcessor):
             
             progress_key = f'{aula_id}-{video_title}-{video_index}'
             
-            progress_key = f'{aula_id}-{video_title}-{video_index}'
-            
-            # Se for baixar vídeo, verifica se j está baixado
+            # Se for baixar vídeo, verifica se já está baixado
             if not self.skip_video and self.is_already_downloaded(progress_key):
                 logger.info(f"⏭️  Já baixado: {video_title}")
                 # ✅ MELHORIA: Mesmo se vídeo já foi baixado, tenta baixar extras se habilitado


### PR DESCRIPTION
### Motivation

- Align project metadata and clean minor source issues after recent edits.  
- Ensure Playwright browser launch uses the configured timeout units to avoid millisecond/second mismatch.  
- Fix lesson indexing so per-lesson/video progress and extras handling use the correct indices.  

### Description

- Bumped README version badge to `v3.1` in `README.md`.  
- Removed stray editor/comment lines from `pdf_processor.py` to restore a clean `__init__` and `process_course` flow.  
- In `video_processor.py` switched lesson iteration to `enumerate(aulas, 1)`, passed the lesson `index` into `_process_lesson`, updated `extract_lesson_info` usage, and cleaned duplicated/incorrect progress-key/commenting around video downloads.  
- In `downloader.py` corrected Playwright `launch_persistent_context` `timeout` to use `self.BROWSER_TIMEOUT` directly instead of multiplying by 1000.  

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985d2e937f88328a3fdb60b7e55cb84)